### PR TITLE
Trl 97

### DIFF
--- a/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
+++ b/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
@@ -1186,7 +1186,6 @@ class _VideoRoomState extends State<VideoRoom> with WidgetsBindingObserver {
                   alignment: Alignment.center,
                   child: GridView.count(
                     childAspectRatio: itemWidth / itemHeight,
-                    shrinkWrap: true,
                     children: [
                       // Render current user's item.
                       VideoGridItem(

--- a/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
+++ b/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
@@ -1153,11 +1153,14 @@ class _VideoRoomState extends State<VideoRoom> with WidgetsBindingObserver {
       initInfra();
     }
 
+    final double heightWithoutBars =
+        MediaQuery.of(context).size.height
+            - kBottomNavigationBarHeight
+            - Scaffold.of(context).appBarMaxHeight;
     final double userGridHeight =
         MediaQuery.of(context).orientation == Orientation.portrait
-            ? (MediaQuery.of(context).size.height - kBottomNavigationBarHeight ) / 2
-            : (MediaQuery.of(context).size.height - kBottomNavigationBarHeight - Scaffold.of(context).appBarMaxHeight);
-
+            ? heightWithoutBars / 2
+            : heightWithoutBars;
     final double userGridWidth =
         MediaQuery.of(context).orientation == Orientation.portrait
             ? MediaQuery.of(context).size.width


### PR DESCRIPTION
Make video items more flexible in the video room:
- Item takes entire height & width of its cell.
- Fix no-video placeholder icon to fit cell.
- This also fixes some mobile landscape overflow issues.