### PR TITLE
Fix some problems

### DIFF
--- a/galaxy_mobile/lib/screens/dashboard/dashboard.dart
+++ b/galaxy_mobile/lib/screens/dashboard/dashboard.dart
@@ -554,6 +554,10 @@ class _DashboardState extends State<Dashboard>
             mqttClient.unsubscribe("galaxy/room/$_activeRoomId");
             // TODO: move to a function.
             mqttClient.unsubscribe("galaxy/room/$_activeRoomId/chat");
+            // TODO: we probably want to support a keyed removal. This currently
+            // removes all callbacks, even the ones set in the Settings screen,
+            // so after we run this code, the previous screen (Settings), will
+            // no longer handle these.
             mqttClient.removeOnConnectedCallback();
             mqttClient.removeOnConnectionFailedCallback();
             mqttClient.removeOnMsgReceivedCallback();

--- a/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
+++ b/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
@@ -1332,6 +1332,7 @@ class _VideoRoomState extends State<VideoRoom> with WidgetsBindingObserver {
         FlutterLogs.logInfo(
             "videoRoom", "didChangeAppLifecycleState", 'inactive');
         // TODO: FIXME: we go to inactive state when moving from Settings to Dashboard (??????)
+        // Maybe this happens when requesting permissions to audio/video.
         if (widget.myStream != null) {
           FlutterLogs.logInfo(
               "videoRoom", "didChangeAppLifecycleState",

--- a/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
+++ b/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
@@ -84,7 +84,7 @@ class VideoRoom extends StatefulWidget {
   List mainToIsolateStream;
   String streamingServer;
 
-  String configuredStreams;
+  String configuredStreams = "{}";
 
   void exitRoom() async {
     if (_janusClient != null) _janusClient.destroy();
@@ -1331,7 +1331,8 @@ class _VideoRoomState extends State<VideoRoom> with WidgetsBindingObserver {
       case AppLifecycleState.inactive:
         FlutterLogs.logInfo(
             "videoRoom", "didChangeAppLifecycleState", 'inactive');
-        // if (!widget.myVideoMuted) {
+        // TODO: FIXME: we go to inactive state when moving from Settings to Dashboard (??????)
+        if (widget.myStream != null) {
           FlutterLogs.logInfo(
               "videoRoom", "didChangeAppLifecycleState",
               'number of video tracks = ${widget.myStream
@@ -1341,13 +1342,17 @@ class _VideoRoomState extends State<VideoRoom> with WidgetsBindingObserver {
               .getVideoTracks()
               .first
               .enabled = false;
-          setState(() {
-            widget.myVideoMuted = true;
-            widget.updateVideoState(true);
-          });
+        } else {
+          FlutterLogs.logInfo(
+              "videoRoom", "didChangeAppLifecycleState",
+              "Widget myStream is null when going to inactive lifecycle state");
+        }
+        setState(() {
+          widget.myVideoMuted = true;
+          widget.updateVideoState(true);
+        });
 
-          widget.updateGoingToBackground();
-        // }
+        widget.updateGoingToBackground();
 
         break;
       case AppLifecycleState.resumed:
@@ -1390,7 +1395,7 @@ class _VideoRoomState extends State<VideoRoom> with WidgetsBindingObserver {
     userData["session"] = widget._janusClient.sessionId;
     userData["handle"] = widget.pluginHandle.handleId;
     userData["extra"] = {};
-    userData["extra"]["streams"]= json.decode(widget.configuredStreams);
+    userData["extra"]["streams"] = json.decode(widget.configuredStreams);
     print("## extra = ${widget.configuredStreams}");
     widget.updateGlxUserCB(userData);
   }

--- a/galaxy_mobile/lib/services/mqtt_client.dart
+++ b/galaxy_mobile/lib/services/mqtt_client.dart
@@ -73,6 +73,10 @@ class MQTTClient {
     _onConnectionFailedCallbackList.clear();
   }
 
+  void removeOnDisconnectedCallback() {
+    _onDisconnectionFailedCallbackList.clear();
+  }
+
   void updateToken(String token)
   {
     print("update mqtt token");

--- a/galaxy_mobile/lib/utils/topics.dart
+++ b/galaxy_mobile/lib/utils/topics.dart
@@ -1,6 +1,10 @@
+
+final String USERS_BROADCAST_TOPIC = "galaxy/users/broadcast";
+
 enum TopicType {
   UNKNOWN,
   ROOM_CHAT,
+  USERS_BROADCAST,
 }
 
 // Class for parsing MQTT topics.
@@ -11,7 +15,9 @@ class Topics {
   static parse(String topic) {
     if (_roomChatPattern.hasMatch(topic)) {
       return TopicType.ROOM_CHAT;
-    }
+    } else if (topic == USERS_BROADCAST_TOPIC) {
+      return TopicType.USERS_BROADCAST;
+    } // TODO: add user topic: "galaxy/users/${user.id}"
 
     return TopicType.UNKNOWN;
   }

--- a/galaxy_mobile/lib/widgets/self_view_widget.dart
+++ b/galaxy_mobile/lib/widgets/self_view_widget.dart
@@ -62,6 +62,7 @@ class _SelfViewWidgetState extends State<SelfViewWidget>
   Future<void> stopCamera() async {
     try {
       await myStream?.dispose();
+      myStream = null;
 
       if (!mounted) {
         return;


### PR DESCRIPTION
Fixes:

1. Settings: 
- Do not run lifecycle methods (i.e., restart selfview camera / stop selfview camera) when the Settings route was pushed.
- Do not restart camera when a the Settings route was popped with an error.
- Add a dispose override to clean up the connectivity subscription.
- Fix MQTT subscription clean up. When going back to Login and Back to Settings, the callbacks would call setState on a previous dead state.

2. SelfViewWidget:
- When camera is restarted, only create a new stream and attach it to an existing RTCVideoRenderer instead of creating a new RTCVideoRenderer.
- When camera is stopped, dispose of the media stream instead of stopping/disabling the first video track.
- Make SelfViewWidget accept a MediaStreamController. Remove a handle to the widget itself in Settings state and build the widget inside the build function while providing the controller.

3. VideoRoomWidget:
- Fix updateGxyUser by setting configuredStreams default's value to an empty JSON object. Previously, this was a null String so decoding threw an error during updateGxyUser call that happened during a life cycle pause (happens when a permission dialog for Audio shows up).