### PR TITLE
Some improvements to horizontal layout

### DIFF
--- a/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
+++ b/galaxy_mobile/lib/screens/video_room/video_room_widget.dart
@@ -1223,6 +1223,7 @@ class _VideoRoomState extends State<VideoRoom> with WidgetsBindingObserver {
 
     final double itemHeight = userGridHeight / 2;
     final double itemWidth = userGridWidth / 2;
+    final safePaddingRight = MediaQuery.of(context).padding.right;
     int pageCount = getNumPages(feeds.length);
 
     FlutterLogs.logInfo(
@@ -1282,6 +1283,7 @@ class _VideoRoomState extends State<VideoRoom> with WidgetsBindingObserver {
                 if (pageCount > 1) Align(
                   alignment: Alignment.centerRight,
                   child: IconButton(
+                    padding: EdgeInsets.only(right: safePaddingRight),
                     color: Colors.blue,
                     icon: DirectionalChild(
                         ltrChildBuilder: (context) => Icon(Icons.arrow_forward),


### PR DESCRIPTION
decided not to go with the plugin `native_device_orientation` just to get landscape right orientation. A drawback of this is that we have the padding always in landscape orientation even when a phone camera on the left side (no need to add the padding)